### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 env:
-- PUPPET_VERSION=2.7.22
+- PUPPET_VERSION=2.7.23
 - PUPPET_VERSION=3.3.2
 notifications:
 email: false
@@ -9,7 +9,7 @@ rvm:
 - 1.8.7
 matrix:
   allow_failures:
-  - env: PUPPET_VERSION=2.7.22
+  - env: PUPPET_VERSION=2.7.23
 language: ruby
 before_script: "gem install --no-ri --no-rdoc bundler"
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>=
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
-gem 'facter', '>= 1.7.0', '< 1.8.0'
+gem 'facter', '>= 1.7.0', "< 1.8.0"

--- a/Rakefile
+++ b/Rakefile
@@ -6,11 +6,11 @@ PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."
 task :validate do
-  Dir['manifests/**/*.pp'].each do |path|
-    sh "puppet parser validate --noop #{path}"
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
   end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |spec_path|
-    sh "ruby -c #{spec_path}" unless spec_path =~ /spec\/fixtures/
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
   end
   Dir['templates/**/*.erb'].each do |template|
     sh "erb -P -x -T '-' #{template} | ruby -c"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -11,7 +11,7 @@ describe 'nisclient' do
         }
       end
 
-      it { should_not include_class('rpcbind') }
+      it { should_not contain_class('rpcbind') }
 
       it {
         should contain_package('nis_package').with({
@@ -78,7 +78,7 @@ describe 'nisclient' do
         }
       end
 
-      it { should include_class('rpcbind') }
+      it { should contain_class('rpcbind') }
 
       it {
         should contain_package('nis_package').with({
@@ -145,7 +145,7 @@ describe 'nisclient' do
         }
       end
 
-      it { should include_class('rpcbind') }
+      it { should contain_class('rpcbind') }
 
       it {
         should contain_package('nis_package').with({
@@ -208,7 +208,7 @@ describe 'nisclient' do
         }
       end
 
-      it { should include_class('rpcbind') }
+      it { should contain_class('rpcbind') }
 
       it {
         should contain_package('nis_package').with({
@@ -272,7 +272,7 @@ describe 'nisclient' do
 
       it 'should fail' do
         expect {
-          should include_class('nisclient')
+          should contain_class('nisclient')
         }.to raise_error(Puppet::Error,/nisclient supports osfamilies Debian, RedHat, and Suse on the Linux kernel. Detected osfamily is <Unsupported>./)
       end
     end
@@ -288,7 +288,7 @@ describe 'nisclient' do
         }
       end
 
-      it { should_not include_class('rpcbind') }
+      it { should_not contain_class('rpcbind') }
 
       it {
         should contain_package('nis_package').with({


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
