### PR TITLE
Added Ubuntu 16.04 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ This module has been tested to work on the following systems with Puppet v3
 
  * EL 5
  * EL 6
+ * EL 7
  * Suse 11
+ * Suse 12
  * Solaris 10
  * Solaris 11
  * Ubuntu 12.04 LTS
+ * Ubuntu 14.04 LTS
+ * Ubuntu 16.04 LTS
 
 ===
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,22 +19,35 @@ class nisclient(
 
   case $::kernel {
     'Linux': {
-      $default_service_name = 'ypbind'
       case $::osfamily {
         'RedHat': {
           $default_package_name = 'ypbind'
+          $default_service_name = 'ypbind'
 
-          if $::lsbmajdistrelease == '6' {
-            include ::rpcbind
+          case $::lsbmajdistrelease {
+            '6', '7': {
+              include ::rpcbind
+            }
           }
         }
         'Suse': {
           include ::rpcbind
           $default_package_name = 'ypbind'
+          $default_service_name = 'ypbind'
         }
         'Debian': {
           include ::rpcbind
           $default_package_name = 'nis'
+          case $::operatingsystemrelease {
+            '16.04': {
+              $default_service_name = 'nis'
+            }
+            default: {
+              # Legacy behavior until Ubuntu 14.04.
+              # Unknown status on non-Ubuntu Debian, so keeping default as it was.
+              $default_service_name = 'ypbind'
+            }
+          }
         }
         default: {
           fail("nisclient supports osfamilies Debian, RedHat, and Suse on the Linux kernel. Detected osfamily is <${::osfamily}>.")

--- a/metadata.json
+++ b/metadata.json
@@ -13,19 +13,22 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "5",
-        "6"
+        "6",
+        "7"
       ]
     },
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {
       "operatingsystem": "SLED",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {
@@ -38,7 +41,9 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04"
+        "12.04",
+        "14.04",
+        "16.04"
       ]
     }
   ],

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -255,6 +255,21 @@ describe 'nisclient' do
           'enable' => 'true',
         })
       }
+
+      context 'with version 16.04' do
+        let :facts do
+          {
+            :operatingsystemrelease => '16.04',
+          }
+        end
+
+        it {
+          should contain_service('nis_service').with({
+            'ensure' => 'running',
+            'name'   => 'nis',
+            'enable' => 'true',
+          })
+      end
     end
 
     context 'with defaults params on unsupported osfamily' do


### PR DESCRIPTION
And added RHEL7 as another supported case in the code (trivial change).
And added SLES12 as another documented case (no code change).

For Ubuntu 16.04 the service name is changed from "ypbind" to "nis".
Since this is the very first Linux platform to do so, the default has to be moved into the various OS branches and needs to be made version-aware on "Debian" track. All other defaults should stay as they are.

Spec test case for Ubuntu 16.04 has been added, but not really tested.
Module itself has been tested with the above mentioned and other Linux OS for regression purpose.