### PR TITLE
Manage /etc/defaultdomain before service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,6 +149,7 @@ class nisclient (
         owner   => 'root',
         group   => 'root',
         mode    => '0644',
+        before  => Service['nis_service'],
         content => "${domainname}\n",
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -197,6 +197,7 @@ describe 'nisclient' do
                 'owner'   => 'root',
                 'group'   => 'root',
                 'mode'    => '0644',
+                'before'  => 'Service[nis_service]',
                 'content' => "example.com\n",
               },
             )


### PR DESCRIPTION
Service fails to start with error 'domainname: No such file or directory' on Ubuntu 22.04 if /etc/defaultdomain does not exist.