### PR TITLE
Release v2.1.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ericsson-nisclient",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": "Ericsson",
   "summary": "Manage the NIS client",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Manage /etc/defaultdomain before service
- Support EL9 and Ubuntu 22.04